### PR TITLE
Support connection to Mosquitto through unix socket

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildDebArchAll()
+buildDebArchAll defaultRunPythonChecks: true

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,11 @@
 .PHONY: all clean
 
+PREFIX = /usr
+
 all:
-clean :
+clean:
 
 install: all
-	install -m 0755 mqtt-upload-dump.py  $(DESTDIR)/usr/bin/mqtt-upload-dump
-	install -m 0755 mqtt-get-dump.py  $(DESTDIR)/usr/bin/mqtt-get-dump
-	install -m 0755 mqtt-delete-retained.py  $(DESTDIR)/usr/bin/mqtt-delete-retained
-
-
-
-
+	install -Dm0755 mqtt-upload-dump.py $(DESTDIR)$(PREFIX)/bin/mqtt-upload-dump
+	install -Dm0755 mqtt-get-dump.py $(DESTDIR)$(PREFIX)/bin/mqtt-get-dump
+	install -Dm0755 mqtt-delete-retained.py $(DESTDIR)$(PREFIX)/bin/mqtt-delete-retained

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+mqtt-tools (1.4.0) stable; urgency=medium
+
+  * Support connection to Mosquitto through unix socket
+  * Use mqtt client wrapper from wb-common
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 28 Feb 2023 16:44:00 +0400
+
 mqtt-tools (1.3.0) stable; urgency=medium
 
   * python3 port using paho.mqtt and tqdm

--- a/debian/control
+++ b/debian/control
@@ -8,5 +8,5 @@ Homepage: https://github.com/wirenboard/mqtt-tools/
 
 Package: mqtt-tools
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python3-all, python3-paho-mqtt, python3-tqdm
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3-all, python3-wb-common (>= 2.1.0), python3-tqdm
 Description: MQTT tools

--- a/mqtt-delete-retained.py
+++ b/mqtt-delete-retained.py
@@ -18,7 +18,7 @@ class DeleteRetainedTool:
 
         self.client = MQTTClient(client_id, broker_url, False)
         self.topic = topic
-        self.retain_hack_topic = "/tmp/%s/retain_hack" % self.client._client_id
+        self.retain_hack_topic = "/tmp/%s/retain_hack" % self.client._client_id.decode()
 
     def run(self):
         self.client.start()

--- a/mqtt-delete-retained.py
+++ b/mqtt-delete-retained.py
@@ -29,7 +29,7 @@ class DeleteRetainedTool:
 
         # hack to get retained settings first:
         self.client.subscribe(self.retain_hack_topic)
-        self.client.publish(self.retain_hack_topic, "1")
+        self.client.publish(self.retain_hack_topic, "1", qos=2)
 
         while 1:
             ret = self.client.loop()

--- a/mqtt-delete-retained.py
+++ b/mqtt-delete-retained.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import argparse
-import signal
 import sys
 
 import tqdm
@@ -82,7 +81,7 @@ class DeleteRetainedTool:
             sys.exit(0)
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(description="MQTT retained message deleter", add_help=False)
     parser.add_argument("-v", "--verbose", dest="verbose", action="store_true", help="Verbose output")
     parser.add_argument(
@@ -105,8 +104,6 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
-
     # For backward compatibility
     if args.host != "localhost" or args.port != 1883 or args.username or args.password:
         if args.username:
@@ -124,3 +121,10 @@ if __name__ == "__main__":
     )
 
     tool.run()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/mqtt-delete-retained.py
+++ b/mqtt-delete-retained.py
@@ -92,10 +92,16 @@ def main():
         help="MQTT broker url",
         default=DEFAULT_BROKER_URL,
     )
-    parser.add_argument("-h", "--host", dest="host", type=str, help="MQTT host (deprecated)", default="localhost")
+    parser.add_argument(
+        "-h", "--host", dest="host", type=str, help="MQTT host (deprecated)", default="localhost"
+    )
     parser.add_argument("-p", "--port", dest="port", type=int, help="MQTT port (deprecated)", default="1883")
-    parser.add_argument("-u", "--username", dest="username", type=str, help="MQTT username (deprecated)", default="")
-    parser.add_argument("-P", "--password", dest="password", type=str, help="MQTT password (deprecated)", default="")
+    parser.add_argument(
+        "-u", "--username", dest="username", type=str, help="MQTT username (deprecated)", default=""
+    )
+    parser.add_argument(
+        "-P", "--password", dest="password", type=str, help="MQTT password (deprecated)", default=""
+    )
     parser.add_argument(
         "topic",
         type=str,

--- a/mqtt-delete-retained.py
+++ b/mqtt-delete-retained.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import signal
 import sys
 
 import tqdm
@@ -99,6 +100,8 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+
+    signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
 
     tool = DeleteRetainedTool(
         "mqtt-delete-retained",

--- a/mqtt-delete-retained.py
+++ b/mqtt-delete-retained.py
@@ -93,6 +93,10 @@ if __name__ == "__main__":
         help="MQTT broker url",
         default=DEFAULT_BROKER_URL,
     )
+    parser.add_argument("-h", "--host", dest="host", type=str, help="MQTT host (deprecated)", default="localhost")
+    parser.add_argument("-p", "--port", dest="port", type=int, help="MQTT port (deprecated)", default="1883")
+    parser.add_argument("-u", "--username", dest="username", type=str, help="MQTT username (deprecated)", default="")
+    parser.add_argument("-P", "--password", dest="password", type=str, help="MQTT password (deprecated)", default="")
     parser.add_argument(
         "topic",
         type=str,
@@ -102,6 +106,15 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
+
+    # For backward compatibility
+    if args.host != "localhost" or args.port != 1883 or args.username or args.password:
+        if args.username:
+            if args.password:
+                userinfo = "%s:%s@" % (args.username, args.password)
+            else:
+                userinfo = "%s@" % args.username
+        args.broker_url = "tcp://%s%s:%s" % (userinfo, args.host, args.port)
 
     tool = DeleteRetainedTool(
         "mqtt-delete-retained",

--- a/mqtt-delete-retained.py
+++ b/mqtt-delete-retained.py
@@ -1,34 +1,27 @@
 #!/usr/bin/env python3
 import argparse
-import random
 import sys
-import time
 
-import paho.mqtt.client as mqtt
 import tqdm
+from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
 
 
 class DeleteRetainedTool:
-    def __init__(self, client_id, host, port, username, password, topic, retain_hack_topic, verbose=False):
+    def __init__(self, client_id, broker_url, topic, verbose=False):
         self.pbar = None
         self.total = 0
 
         self.verbose = verbose
-        self.retain_hack_topic = retain_hack_topic
 
         self.topics_to_unpublish = set()
         self.unpublished_topics = set()
 
-        self.client = mqtt.Client(client_id)
-        if username:
-            self.client.username_pw_set(username, password)
-
-        self.host = host
-        self.port = port
+        self.client = MQTTClient(client_id, broker_url, False)
         self.topic = topic
+        self.retain_hack_topic = "/tmp/%s/retain_hack" % self.client._client_id
 
     def run(self):
-        self.client.connect(self.host, self.port)
+        self.client.start()
         self.client.on_message = self.on_mqtt_message
 
         self.client.subscribe(self.topic)
@@ -71,7 +64,7 @@ class DeleteRetainedTool:
                     self.pbar.close()
                 else:
                     print("warning: no messages for this topic")
-                self.client.disconnect()
+                self.client.stop()
                 sys.exit(0)
 
     def on_mqtt_publish(self, _, arg1, arg2=None):
@@ -84,32 +77,21 @@ class DeleteRetainedTool:
                 print("topics published")
             if self.pbar:
                 self.pbar.close()
-            self.client.disconnect()
+            self.client.stop()
             sys.exit(0)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="MQTT retained message deleter", add_help=False)
     parser.add_argument("-v", "--verbose", dest="verbose", action="store_true", help="Verbose output")
-
-    parser.add_argument("-h", "--host", dest="host", type=str, help="MQTT host", default="localhost")
-
-    parser.add_argument("-p", "--port", dest="port", type=int, help="MQTT port", default="1883")
-
-    parser.add_argument("-u", "--username", dest="username", type=str, help="MQTT username", default="")
-
-    parser.add_argument("-P", "--password", dest="password", type=str, help="MQTT password", default="")
-
-    mqtt_device_id = str(time.time()) + str(random.randint(0, 100000))
-
     parser.add_argument(
-        "--ret-topic",
-        dest="ret_topic",
+        "-b",
+        "--broker",
+        dest="broker_url",
         type=str,
-        help="Topic to write temporary message to",
-        default="/tmp/%s/retain_hack" % (mqtt_device_id),
+        help="MQTT broker url",
+        default=DEFAULT_BROKER_URL,
     )
-
     parser.add_argument(
         "topic",
         type=str,
@@ -119,13 +101,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     tool = DeleteRetainedTool(
-        mqtt_device_id,
-        args.host,
-        args.port,
-        args.username,
-        args.password,
+        "mqtt-delete-retained",
+        args.broker_url,
         args.topic,
-        retain_hack_topic=args.ret_topic,
         verbose=args.verbose,
     )
 

--- a/mqtt-get-dump.py
+++ b/mqtt-get-dump.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import signal
 import sys
 
 from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
@@ -57,6 +58,8 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+
+    signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
 
     tool = GetDumpTool(
         "mqtt-get-dump",

--- a/mqtt-get-dump.py
+++ b/mqtt-get-dump.py
@@ -21,7 +21,7 @@ class GetDumpTool:
 
         # hack to get retained settings first:
         self.client.subscribe(self.ret_topic)
-        self.client.publish(self.ret_topic, "1")
+        self.client.publish(self.ret_topic, "1", qos=2)
 
         while 1:
             ret = self.client.loop()

--- a/mqtt-get-dump.py
+++ b/mqtt-get-dump.py
@@ -50,10 +50,16 @@ def main():
         help="MQTT broker url",
         default=DEFAULT_BROKER_URL,
     )
-    parser.add_argument("-h", "--host", dest="host", type=str, help="MQTT host (deprecated)", default="localhost")
+    parser.add_argument(
+        "-h", "--host", dest="host", type=str, help="MQTT host (deprecated)", default="localhost"
+    )
     parser.add_argument("-p", "--port", dest="port", type=int, help="MQTT port (deprecated)", default="1883")
-    parser.add_argument("-u", "--username", dest="username", type=str, help="MQTT username (deprecated)", default="")
-    parser.add_argument("-P", "--password", dest="password", type=str, help="MQTT password (deprecated)", default="")
+    parser.add_argument(
+        "-u", "--username", dest="username", type=str, help="MQTT username (deprecated)", default=""
+    )
+    parser.add_argument(
+        "-P", "--password", dest="password", type=str, help="MQTT password (deprecated)", default=""
+    )
     parser.add_argument(
         "topic",
         type=str,

--- a/mqtt-get-dump.py
+++ b/mqtt-get-dump.py
@@ -1,26 +1,19 @@
 #!/usr/bin/env python3
 import argparse
-import random
 import sys
-import time
 
-import paho.mqtt.client as mqtt
+from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
 
 
 class GetDumpTool:
-    def __init__(self, host, port, username, password, topic, ret_topic):
-        self.client = mqtt.Client()
+    def __init__(self, client_id, broker_url, topic):
+        self.client = MQTTClient(client_id, broker_url, False)
 
-        if username:
-            self.client.username_pw_set(username, password)
-
-        self.host = host
-        self.port = port
         self.topic = topic
-        self.ret_topic = ret_topic
+        self.ret_topic = "/tmp/%s/retain_hack" % self.client._client_id
 
     def run(self):
-        self.client.connect(self.host, self.port)
+        self.client.start()
         self.client.on_message = self.on_mqtt_message
 
         self.client.subscribe(self.topic)
@@ -43,31 +36,20 @@ class GetDumpTool:
         if msg.topic != self.ret_topic:
             print("%s\t%s" % (msg.topic, msg.payload.decode("utf-8").replace("\n", "\\\n")))
         else:
-            self.client.disconnect()
+            self.client.stop()
             sys.exit(0)
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="MQTT retained message deleter", add_help=False)
-
-    parser.add_argument("-h", "--host", dest="host", type=str, help="MQTT host", default="localhost")
-
-    parser.add_argument("-u", "--username", dest="username", type=str, help="MQTT username", default="")
-
-    parser.add_argument("-P", "--password", dest="password", type=str, help="MQTT password", default="")
-
-    parser.add_argument("-p", "--port", dest="port", type=int, help="MQTT port", default="1883")
-
-    mqtt_device_id = str(time.time()) + str(random.randint(0, 100000))
-
+    parser = argparse.ArgumentParser(description="MQTT get dump", add_help=False)
     parser.add_argument(
-        "--ret-topic",
-        dest="ret_topic",
+        "-b",
+        "--broker",
+        dest="broker_url",
         type=str,
-        help="Topic to write temporary message to",
-        default="/tmp/%s/retain_hack" % (mqtt_device_id),
+        help="MQTT broker url",
+        default=DEFAULT_BROKER_URL,
     )
-
     parser.add_argument(
         "topic",
         type=str,
@@ -77,11 +59,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     tool = GetDumpTool(
-        args.host,
-        args.port,
-        args.username,
-        args.password,
+        "mqtt-get-dump",
+        args.broker_url,
         args.topic,
-        args.ret_topic,
     )
     tool.run()

--- a/mqtt-get-dump.py
+++ b/mqtt-get-dump.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import argparse
-import signal
 import sys
 
 from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
@@ -41,7 +40,7 @@ class GetDumpTool:
             sys.exit(0)
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(description="MQTT get dump", add_help=False)
     parser.add_argument(
         "-b",
@@ -63,8 +62,6 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
-
     # For backward compatibility
     if args.host != "localhost" or args.port != 1883 or args.username or args.password:
         if args.username:
@@ -80,3 +77,10 @@ if __name__ == "__main__":
         args.topic,
     )
     tool.run()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/mqtt-get-dump.py
+++ b/mqtt-get-dump.py
@@ -10,7 +10,7 @@ class GetDumpTool:
         self.client = MQTTClient(client_id, broker_url, False)
 
         self.topic = topic
-        self.ret_topic = "/tmp/%s/retain_hack" % self.client._client_id
+        self.ret_topic = "/tmp/%s/retain_hack" % self.client._client_id.decode()
 
     def run(self):
         self.client.start()

--- a/mqtt-get-dump.py
+++ b/mqtt-get-dump.py
@@ -51,6 +51,10 @@ if __name__ == "__main__":
         help="MQTT broker url",
         default=DEFAULT_BROKER_URL,
     )
+    parser.add_argument("-h", "--host", dest="host", type=str, help="MQTT host (deprecated)", default="localhost")
+    parser.add_argument("-p", "--port", dest="port", type=int, help="MQTT port (deprecated)", default="1883")
+    parser.add_argument("-u", "--username", dest="username", type=str, help="MQTT username (deprecated)", default="")
+    parser.add_argument("-P", "--password", dest="password", type=str, help="MQTT password (deprecated)", default="")
     parser.add_argument(
         "topic",
         type=str,
@@ -60,6 +64,15 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
+
+    # For backward compatibility
+    if args.host != "localhost" or args.port != 1883 or args.username or args.password:
+        if args.username:
+            if args.password:
+                userinfo = "%s:%s@" % (args.username, args.password)
+            else:
+                userinfo = "%s@" % args.username
+        args.broker_url = "tcp://%s%s:%s" % (userinfo, args.host, args.port)
 
     tool = GetDumpTool(
         "mqtt-get-dump",

--- a/mqtt-upload-dump.py
+++ b/mqtt-upload-dump.py
@@ -100,6 +100,10 @@ if __name__ == "__main__":
         help="MQTT broker url",
         default=DEFAULT_BROKER_URL,
     )
+    parser.add_argument("-h", "--host", dest="host", type=str, help="MQTT host (deprecated)", default="localhost")
+    parser.add_argument("-p", "--port", dest="port", type=int, help="MQTT port (deprecated)", default="1883")
+    parser.add_argument("-u", "--username", dest="username", type=str, help="MQTT username (deprecated)", default="")
+    parser.add_argument("-P", "--password", dest="password", type=str, help="MQTT password (deprecated)", default="")
     parser.add_argument("-v", "--verbose", dest="verbose", action="store_true", help="Verbose output")
     parser.add_argument(
         "filename", type=str, help="File containing MQTT dump.  Topic and message are separated by tab"
@@ -108,6 +112,15 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
+
+    # For backward compatibility
+    if args.host != "localhost" or args.port != 1883 or args.username or args.password:
+        if args.username:
+            if args.password:
+                userinfo = "%s:%s@" % (args.username, args.password)
+            else:
+                userinfo = "%s@" % args.username
+        args.broker_url = "tcp://%s%s:%s" % (userinfo, args.host, args.port)
 
     tool = UploadDumpTool(
         "mqtt-upload-dump",

--- a/mqtt-upload-dump.py
+++ b/mqtt-upload-dump.py
@@ -2,18 +2,14 @@
 import argparse
 import sys
 
-import paho.mqtt.client as mqtt
 import tqdm
+from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
 
 
 class UploadDumpTool:
-    def __init__(self, host, port, username, password, filename, verbose=False):
-        self.client = mqtt.Client()
-        if username:
-            self.client.username_pw_set(username, password)
+    def __init__(self, client_id, broker_url, filename, verbose=False):
+        self.client = MQTTClient(client_id, broker_url, False)
 
-        self.host = host
-        self.port = port
         self.filename = filename
         self.verbose = verbose
 
@@ -58,7 +54,7 @@ class UploadDumpTool:
                 full_msg = None
 
     def run(self):
-        self.client.connect(self.host, self.port)
+        self.client.start()
         self.client.on_publish = self.on_mqtt_publish
 
         mid = None
@@ -88,24 +84,22 @@ class UploadDumpTool:
             self.pbar.update(1)
         # print mid, last_mid
         if self.last_mid and (self.last_mid == mid):
-            self.client.disconnect()
+            self.client.stop()
             self.pbar.close()
             sys.exit(0)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="publish mqtt messages to broker", add_help=False)
-
-    parser.add_argument("-h", "--host", dest="host", type=str, help="MQTT host", default="localhost")
-
-    parser.add_argument("-p", "--port", dest="port", type=int, help="MQTT port", default="1883")
-
-    parser.add_argument("-u", "--username", dest="username", type=str, help="MQTT username", default="")
-
-    parser.add_argument("-P", "--password", dest="password", type=str, help="MQTT password", default="")
-
+    parser.add_argument(
+        "-b",
+        "--broker",
+        dest="broker_url",
+        type=str,
+        help="MQTT broker url",
+        default=DEFAULT_BROKER_URL,
+    )
     parser.add_argument("-v", "--verbose", dest="verbose", action="store_true", help="Verbose output")
-
     parser.add_argument(
         "filename", type=str, help="File containing MQTT dump.  Topic and message are separated by tab"
     )
@@ -113,10 +107,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     tool = UploadDumpTool(
-        args.host,
-        args.port,
-        args.username,
-        args.password,
+        "mqtt-upload-dump",
+        args.broker_url,
         args.filename,
         verbose=args.verbose,
     )

--- a/mqtt-upload-dump.py
+++ b/mqtt-upload-dump.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import argparse
-import signal
 import sys
 
 import tqdm
@@ -90,7 +89,7 @@ class UploadDumpTool:
             sys.exit(0)
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(description="publish mqtt messages to broker", add_help=False)
     parser.add_argument(
         "-b",
@@ -111,8 +110,6 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
-
     # For backward compatibility
     if args.host != "localhost" or args.port != 1883 or args.username or args.password:
         if args.username:
@@ -129,3 +126,10 @@ if __name__ == "__main__":
         verbose=args.verbose,
     )
     tool.run()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/mqtt-upload-dump.py
+++ b/mqtt-upload-dump.py
@@ -99,10 +99,16 @@ def main():
         help="MQTT broker url",
         default=DEFAULT_BROKER_URL,
     )
-    parser.add_argument("-h", "--host", dest="host", type=str, help="MQTT host (deprecated)", default="localhost")
+    parser.add_argument(
+        "-h", "--host", dest="host", type=str, help="MQTT host (deprecated)", default="localhost"
+    )
     parser.add_argument("-p", "--port", dest="port", type=int, help="MQTT port (deprecated)", default="1883")
-    parser.add_argument("-u", "--username", dest="username", type=str, help="MQTT username (deprecated)", default="")
-    parser.add_argument("-P", "--password", dest="password", type=str, help="MQTT password (deprecated)", default="")
+    parser.add_argument(
+        "-u", "--username", dest="username", type=str, help="MQTT username (deprecated)", default=""
+    )
+    parser.add_argument(
+        "-P", "--password", dest="password", type=str, help="MQTT password (deprecated)", default=""
+    )
     parser.add_argument("-v", "--verbose", dest="verbose", action="store_true", help="Verbose output")
     parser.add_argument(
         "filename", type=str, help="File containing MQTT dump.  Topic and message are separated by tab"

--- a/mqtt-upload-dump.py
+++ b/mqtt-upload-dump.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import signal
 import sys
 
 import tqdm
@@ -105,6 +106,8 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+
+    signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
 
     tool = UploadDumpTool(
         "mqtt-upload-dump",


### PR DESCRIPTION
Depends on https://github.com/wirenboard/wb-common/pull/8

Test instructions:
```sh
~ mqtt-get-dump -b unix:///var/run/mosquitto/mosquitto.sock '$SYS/broker/messages/#'
$SYS/broker/messages/stored	829
$SYS/broker/messages/received	938511
$SYS/broker/messages/sent	2552220
~ mqtt-get-dump -b tcp://127.0.0.1:1883 '$SYS/broker/messages/#'
$SYS/broker/messages/stored	830
$SYS/broker/messages/received	938836
$SYS/broker/messages/sent	2553517
~ mqtt-get-dump -b ws://127.0.0.1:18883 '$SYS/broker/messages/#'
$SYS/broker/messages/stored	830
$SYS/broker/messages/received	939114
$SYS/broker/messages/sent	2554565
```