### PR TITLE
mqtt-delete-retained: fix runtime error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mqtt-tools (1.4.1) stable; urgency=medium
+
+  * mqtt-delete-retained: fix runtime error
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 10 Mar 2023 09:39:00 +0400
+
 mqtt-tools (1.4.0) stable; urgency=medium
 
   * Support connection to Mosquitto through unix socket

--- a/mqtt-delete-retained.py
+++ b/mqtt-delete-retained.py
@@ -49,7 +49,7 @@ class DeleteRetainedTool:
             self.total += 1
         else:
             self.client.on_publish = self.on_mqtt_publish
-            self.client.unsubscribe(args.topic)
+            self.client.unsubscribe(self.topic)
             if self.topics_to_unpublish:
                 self.pbar = tqdm.tqdm(total=self.total)
                 for topic in self.topics_to_unpublish:


### PR DESCRIPTION
```sh
$ mqtt-delete-retained -b unix:///var/run/mosquitto/mosquitto.sock '/test/#'
Traceback (most recent call last):
  File "/usr/bin/mqtt-delete-retained", line 134, in <module>
    main()
  File "/usr/bin/mqtt-delete-retained", line 129, in main
    tool.run()
  File "/usr/bin/mqtt-delete-retained", line 34, in run
    ret = self.client.loop()
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 1181, in loop
    rc = self.loop_read(max_packets)
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 1572, in loop_read
    rc = self._packet_read()
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 2310, in _packet_read
    rc = self._packet_handle()
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 2936, in _packet_handle
    return self._handle_publish()
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 3216, in _handle_publish
    self._handle_on_message(message)
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 3444, in _handle_on_message
    self.on_message(self, self._userdata, message)
  File "/usr/bin/mqtt-delete-retained", line 52, in on_mqtt_message
    self.client.unsubscribe(args.topic)
NameError: name 'args' is not defined
```