### PR TITLE
Fix connection error handling

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,3 @@
-buildDebArchAll defaultRunPythonChecks: true
+buildDebArchAll defaultRunPythonChecks: true,
+                defaultAngryPylint: true,
+                defaultRunLintian: true

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mqtt-tools (1.4.2) stable; urgency=medium
+
+  * Fix exception on connection error
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 07 Aug 2023 13:26:00 +0400
+
 mqtt-tools (1.4.1) stable; urgency=medium
 
   * mqtt-delete-retained: fix runtime error

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 mqtt-tools (1.4.2) stable; urgency=medium
 
-  * Fix exception on connection error
+  * Fix connection error handling
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 07 Aug 2023 13:26:00 +0400
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Evgeny Boger <boger@contactless.ru>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), pkg-config
+Build-Depends: debhelper (>= 9), pkg-config, python3-wb-common, python3-tqdm
 Homepage: https://github.com/wirenboard/mqtt-tools/
 
 Package: mqtt-tools

--- a/mqtt-delete-retained.py
+++ b/mqtt-delete-retained.py
@@ -133,7 +133,7 @@ def main():
     )
     try:
         tool.run()
-    except ConnectionRefusedError:
+    except (ConnectionError, ConnectionRefusedError):
         logger.error("Cannot connect to broker %s", args.broker_url)
 
 

--- a/mqtt-delete-retained.py
+++ b/mqtt-delete-retained.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
+# pylint: disable=invalid-name
 import argparse
+import logging
 import sys
 
 import tqdm
 from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
 
+logger = logging.getLogger(__name__)
 
+
+# pylint: disable=too-many-instance-attributes
 class DeleteRetainedTool:
     def __init__(self, client_id, broker_url, topic, verbose=False):
         self.pbar = None
@@ -18,7 +23,7 @@ class DeleteRetainedTool:
 
         self.client = MQTTClient(client_id, broker_url, False)
         self.topic = topic
-        self.retain_hack_topic = "/tmp/%s/retain_hack" % self.client._client_id.decode()
+        self.retain_hack_topic = f"/tmp/{self.client._client_id.decode()}/retain_hack"
 
     def run(self):
         self.client.start()
@@ -112,12 +117,13 @@ def main():
 
     # For backward compatibility
     if args.host != "localhost" or args.port != 1883 or args.username or args.password:
+        userinfo = ""
         if args.username:
             if args.password:
-                userinfo = "%s:%s@" % (args.username, args.password)
+                userinfo = f"{args.username}:{args.password}@"
             else:
-                userinfo = "%s@" % args.username
-        args.broker_url = "tcp://%s%s:%s" % (userinfo, args.host, args.port)
+                userinfo = f"{args.username}@"
+        args.broker_url = f"tcp://{userinfo}{args.host}:{args.port}"
 
     tool = DeleteRetainedTool(
         "mqtt-delete-retained",
@@ -125,8 +131,10 @@ def main():
         args.topic,
         verbose=args.verbose,
     )
-
-    tool.run()
+    try:
+        tool.run()
+    except ConnectionRefusedError:
+        logger.error("Cannot connect to broker %s", args.broker_url)
 
 
 if __name__ == "__main__":

--- a/mqtt-get-dump.py
+++ b/mqtt-get-dump.py
@@ -89,7 +89,7 @@ def main():
     )
     try:
         tool.run()
-    except ConnectionRefusedError:
+    except (ConnectionError, ConnectionRefusedError):
         logger.error("Cannot connect to broker %s", args.broker_url)
 
 

--- a/mqtt-get-dump.py
+++ b/mqtt-get-dump.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
+# pylint: disable=invalid-name
 import argparse
+import logging
 import sys
 
 from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
+
+logger = logging.getLogger(__name__)
 
 
 class GetDumpTool:
@@ -10,7 +14,7 @@ class GetDumpTool:
         self.client = MQTTClient(client_id, broker_url, False)
 
         self.topic = topic
-        self.ret_topic = "/tmp/%s/retain_hack" % self.client._client_id.decode()
+        self.ret_topic = f"/tmp/{self.client._client_id.decode()}/retain_hack"
 
     def run(self):
         self.client.start()
@@ -70,19 +74,23 @@ def main():
 
     # For backward compatibility
     if args.host != "localhost" or args.port != 1883 or args.username or args.password:
+        userinfo = ""
         if args.username:
             if args.password:
-                userinfo = "%s:%s@" % (args.username, args.password)
+                userinfo = f"{args.username}:{args.password}@"
             else:
-                userinfo = "%s@" % args.username
-        args.broker_url = "tcp://%s%s:%s" % (userinfo, args.host, args.port)
+                userinfo = f"{args.username}@"
+        args.broker_url = f"tcp://{userinfo}{args.host}:{args.port}"
 
     tool = GetDumpTool(
         "mqtt-get-dump",
         args.broker_url,
         args.topic,
     )
-    tool.run()
+    try:
+        tool.run()
+    except ConnectionRefusedError:
+        logger.error("Cannot connect to broker %s", args.broker_url)
 
 
 if __name__ == "__main__":

--- a/mqtt-upload-dump.py
+++ b/mqtt-upload-dump.py
@@ -138,7 +138,7 @@ def main():
     )
     try:
         tool.run()
-    except ConnectionRefusedError:
+    except (ConnectionError, ConnectionRefusedError):
         logger.error("Cannot connect to broker %s", args.broker_url)
 
 


### PR DESCRIPTION
* `homeui` в `postinst` вызывает `mqtt-get-dump` (https://github.com/wirenboard/homeui/blob/e2a1774a2a28e39c6e1512c10c1f7dc38fd19123/debian/postinst#L47), что каждый раз при сборке фита приводит к:
```sh
Traceback (most recent call last):
  File "/usr/bin/mqtt-get-dump", line 90, in <module>
    main()
  File "/usr/bin/mqtt-get-dump", line 85, in main
    tool.run()
  File "/usr/bin/mqtt-get-dump", line 16, in run
    self.client.start()
  File "/usr/lib/python3/dist-packages/wb_common/mqtt_client.py", line 33, in start
    self.sock_connect(self._broker_url.path)
  File "/usr/lib/python3/dist-packages/paho_socket/client.py", line 45, in sock_connect
    return self.reconnect()
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 1075, in reconnect
    sock = self._create_socket_connection()
  File "/usr/lib/python3/dist-packages/paho_socket/client.py", line 105, in _create_socket_connection
    raise ConnectionError("Socket connection failed.") from ex
ConnectionError: Socket connection failed.
```
Теперь поведение следующее:
```sh
$ systemctl stop mosquitto
$ mqtt-get-dump '/config/#'
Cannot connect to broker unix:///var/run/mosquitto/mosquitto.sock
```
* Поправлено:
```sh
$ mqtt-get-dump -p 111 '/config/#'
Traceback (most recent call last):
  File "/usr/bin/mqtt-get-dump", line 90, in <module>
    main()
  File "/usr/bin/mqtt-get-dump", line 78, in main
    args.broker_url = "tcp://%s%s:%s" % (userinfo, args.host, args.port)
UnboundLocalError: local variable 'userinfo' referenced before assignment
```
* Jenkinsfile: включен defaultAngryPylint (использовать f-string) и defaultRunLintian