### PR TITLE
Fix error handling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mqtt-tools (1.4.4) stable; urgency=medium
+
+  * Fix error handling
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 29 Jan 2024 16:15:00 +0400
+
 mqtt-tools (1.4.3) stable; urgency=medium
 
   * Fix pylint errors. No functional changes

--- a/mqtt-delete-retained.py
+++ b/mqtt-delete-retained.py
@@ -136,8 +136,10 @@ def main():
         tool.run()
     except (ConnectionError, ConnectionRefusedError):
         logger.error("Cannot connect to broker %s", args.broker_url)
+        sys.exit(1)
     except ValueError as err:
         logger.error(err)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/mqtt-delete-retained.py
+++ b/mqtt-delete-retained.py
@@ -136,6 +136,8 @@ def main():
         tool.run()
     except (ConnectionError, ConnectionRefusedError):
         logger.error("Cannot connect to broker %s", args.broker_url)
+    except ValueError as err:
+        logger.error(err)
 
 
 if __name__ == "__main__":

--- a/mqtt-get-dump.py
+++ b/mqtt-get-dump.py
@@ -92,8 +92,10 @@ def main():
         tool.run()
     except (ConnectionError, ConnectionRefusedError):
         logger.error("Cannot connect to broker %s", args.broker_url)
+        sys.exit(1)
     except ValueError as err:
         logger.error(err)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/mqtt-get-dump.py
+++ b/mqtt-get-dump.py
@@ -92,6 +92,8 @@ def main():
         tool.run()
     except (ConnectionError, ConnectionRefusedError):
         logger.error("Cannot connect to broker %s", args.broker_url)
+    except ValueError as err:
+        logger.error(err)
 
 
 if __name__ == "__main__":

--- a/mqtt-upload-dump.py
+++ b/mqtt-upload-dump.py
@@ -141,8 +141,10 @@ def main():
         tool.run()
     except (ConnectionError, ConnectionRefusedError):
         logger.error("Cannot connect to broker %s", args.broker_url)
+        sys.exit(1)
     except FileNotFoundError as e:
         logger.error("File not found: %s", e.filename)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/mqtt-upload-dump.py
+++ b/mqtt-upload-dump.py
@@ -141,6 +141,8 @@ def main():
         tool.run()
     except (ConnectionError, ConnectionRefusedError):
         logger.error("Cannot connect to broker %s", args.broker_url)
+    except FileNotFoundError as e:
+        logger.error("File not found: %s", e.filename)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Before:
```sh
$ mqtt-get-dump '/devices#'
Traceback (most recent call last):
  File "/usr/bin/mqtt-get-dump", line 99, in <module>
    main()
  File "/usr/bin/mqtt-get-dump", line 92, in main
    tool.run()
  File "/usr/bin/mqtt-get-dump", line 24, in run
    self.client.subscribe(self.topic)
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 1507, in subscribe
    raise ValueError('Invalid subscription filter.')
ValueError: Invalid subscription filter.
$ mqtt-upload-dump dump.txt
Traceback (most recent call last):
  File "/usr/bin/mqtt-upload-dump", line 148, in <module>
    main()
  File "/usr/bin/mqtt-upload-dump", line 141, in main
    tool.run()
  File "/usr/bin/mqtt-upload-dump", line 67, in run
    for topic, full_msg in self.parse_dump(self.filename):
  File "/usr/bin/mqtt-upload-dump", line 28, in parse_dump
    with open(filename, encoding="utf-8") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'dump.txt'
```

After:
```sh
$ mqtt-get-dump '/devices#'
Invalid subscription filter.
$ mqtt-upload-dump dump.txt
File not found: dump.txt
```